### PR TITLE
Fix Win Powershell: BOM + authorization

### DIFF
--- a/terraform/modules/vm/vm.tf
+++ b/terraform/modules/vm/vm.tf
@@ -48,7 +48,10 @@ resource "null_resource" "vm_save_ssh_key_windows" {
     interpreter = ["PowerShell"]
     command = <<EOF
       md ${path.module}\\.ssh
-      echo "${tls_private_key.vm_ssh_key.private_key_pem}" > ${path.module}\\.ssh\\${local.my_private_key}
+      [IO.File]::WriteAllLines(("${path.module}\.ssh\${local.my_private_key}"), "${tls_private_key.vm_ssh_key.private_key_pem}")
+      icacls ${path.module}\.ssh\${local.my_private_key} /reset
+      icacls ${path.module}\.ssh\${local.my_private_key} /grant:r "$($env:USERNAME):(R,W)"
+      icacls ${path.module}\.ssh\${local.my_private_key} /inheritance:r
 EOF
   }
 }


### PR DESCRIPTION
1. the key should be with right format in Windows UTF-8, without BOM. 
Solution: WriteAllLines should write UTF-8 without BOM. Requires Powershell 4.0+ (Windows 8.1+, Windows server 2012 R2+).

2. Private key should be with working rights (chmod 0600 - to fix issue with ssh client, not accepting the key). 
Solution: First we'll reset all rights, then grand only read+write rights to the current user, then remove the inheritance (=> only current logged in user is authorized to edit the private key.